### PR TITLE
Remove dependency on "has"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var has = require('has');
 var isarray = require('isarray');
 
 var VERSION = '1.0.0';
@@ -66,8 +65,8 @@ RPC.prototype.apply = function (method, args) {
 RPC.prototype._handle = function (msg) {
     var self = this;
     if (self._destroyed) return;
-    if (has(msg, 'method')) {
-        if (!has(this._methods, msg.method)) return;
+    if (msg.hasOwnProperty('method')) {
+        if (!this._methods.hasOwnProperty(msg.method)) return;
         var args = msg.arguments.concat(function () {
             self.dst.postMessage({
                 protocol: 'frame-rpc',
@@ -78,7 +77,7 @@ RPC.prototype._handle = function (msg) {
         });
         this._methods[msg.method].apply(this._methods, args);
     }
-    else if (has(msg, 'response')) {
+    else if (msg.hasOwnProperty('response')) {
         var cb = this._callbacks[msg.response];
         delete this._callbacks[msg.response];
         if (cb) cb.apply(null, msg.arguments);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "rpc between iframes and windows using postMessage with no serialization",
   "main": "index.js",
   "dependencies": {
-    "has": "~1.0.0",
     "isarray": "~0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The has module relies on function-bind which is implemented using
the Function constructor. This violates unsafe-eval Content Security
Protection, making frame-rpc unusable in such a CSP environment.

This seems like a large cost to pay in exchange for saving a few
characters of code.
